### PR TITLE
wth - (Fulfillment) Participant Tracker: Stop Defaulting Service

### DIFF
--- a/app/assets/javascripts/appointments.js.coffee
+++ b/app/assets/javascripts/appointments.js.coffee
@@ -58,23 +58,27 @@ $ ->
         url: "/appointments/#{id}.js"
 
   $(document).on 'click', '.add_service', ->
-    data =
-      'appointment_id': $(this).parents('.row.appointment').data('id'),
-      'service_id': $('#service_list').val(),
-      'qty': $('#service_quantity').val()
+    if $('#service_list').val() == ''
+      $('.service-error').removeClass('hidden')
+    else
+      $('.service-error').addClass('hidden')
+      data =
+        'appointment_id': $(this).parents('.row.appointment').data('id'),
+        'service_id': $('#service_list').val(),
+        'qty': $('#service_quantity').val()
 
-    $.ajax
-      type: 'POST'
-      url:  "/procedures.js"
-      data: data
-      success: ->
-        new_rows    = $('tr.procedure.new_service')
-        core        = $(new_rows).first().parents('.core')
-        multiselect = $(core).find('select.core_multiselect')
-        pg          = new ProcedureGrouper()
+      $.ajax
+        type: 'POST'
+        url:  "/procedures.js"
+        data: data
+        success: ->
+          new_rows    = $('tr.procedure.new_service')
+          core        = $(new_rows).first().parents('.core')
+          multiselect = $(core).find('select.core_multiselect')
+          pg          = new ProcedureGrouper()
 
-        pg.update_group_membership new_row for new_row in new_rows
-        pg.initialize_multiselect(multiselect)
+          pg.update_group_membership new_row for new_row in new_rows
+          pg.initialize_multiselect(multiselect)
 
   $(document).on 'click', '.start_visit', ->
     appointment_id = $(this).parents('.row.appointment').data('id')

--- a/app/views/appointments/_calendar.html.haml
+++ b/app/views/appointments/_calendar.html.haml
@@ -40,7 +40,10 @@
             = render partial: '/appointments/core', locals: {core_id: core_id, procedures: procedures, appointment: appointment}
       .row.services
         .col-xs-4
-          = select_tag "service_list", options_from_collection_for_select(appointment.protocol.organization.inclusive_child_services(:per_participant), "id", "name"), class: 'form-control selectpicker'
+          = select_tag "service_list", options_from_collection_for_select(appointment.protocol.organization.inclusive_child_services(:per_participant), "id", "name"), class: 'form-control selectpicker', prompt: 'Nothing Selected'
+          %span.help-block.service-error.hidden
+            %p.text-danger
+              = t(:appointment)[:service_error]
         .col-xs-2
           = text_field_tag "service_quantity", 1, class: "form-control"
         .col-xs-2

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,6 +90,7 @@ en:
     protocol_id: "Protocol ID"
     reason: "Reason"
     reset_visit: "Reset Visit"
+    service_error: 'Please choose the service that is desired to be added'
     srid: "SRID"
     start_date: "Start Date:"
     start_time: "Start Time:"


### PR DESCRIPTION
Background: In Fulfillment Participant Tracker, after chosen a visit, at
the bottom of the page, there is a dropdown box for the clinical
providers to be able to add more services (procedures). Currently, it is
always defaulting to be the first service of the dropdown box.

1). Changed the default to "Nothing Selected", so that the users won't
accidentally add the first service;
and
2). Added an error message for "Please choose the service that is desired
to be added." when there is no service chosen when "Add" is clicked.

[#145460053]

Story - (https://www.pivotaltracker.com/story/show/145460053)