### PR TITLE
wth - (Fulfillment) Study Schedule Change Service Label and Arm Name

### DIFF
--- a/app/views/reports/_auditing_report.html.haml
+++ b/app/views/reports/_auditing_report.html.haml
@@ -37,7 +37,12 @@
             .form-group
               = label_tag "service_type", t(:reports)[:service_type]+t(:actions)[:required], class: "col-sm-3 control-label"
               .col-sm-9
-                = select_tag "service_type", options_for_select(["One Time Fees", "Per Patient Per Visit"]), include_blank: true, class: "selectpicker form-control", id: "service_type_select", title: "Select a Service Type"
+                = select_tag "service_type",
+                  options_for_select(Constants::AUDITING_REPORT_SERVICE_TYPES),
+                  include_blank: true,
+                  class: "selectpicker form-control",
+                  id: "service_type_select",
+                  title: "Select a Service Type"
             .form-group
               =label_tag "title", t(:documents)[:title]+t(:actions)[:required], class: "col-sm-3 control-label"
               .col-sm-9= text_field_tag "title", title, class: "form-control"

--- a/app/views/study_schedule/_arm.html.haml
+++ b/app/views/study_schedule/_arm.html.haml
@@ -23,7 +23,10 @@
   .study_schedule.service{class: "arm_#{arm.id}"}
     .row.header
       .col-xs-4.text-center.study_schedule_table_name
-        %span{id: "arm-name-display-#{arm.id}"}= arm.name
+        %span{id: "arm-name-display-#{arm.id}"}
+          = t(:arm)[:header]
+          %br
+          = t('arm.name_with_arm_name_interpolated', arm_name: arm.name)
       .col-xs-8.text-center.visit_group_select{id: "select_for_arm_#{arm.id}"}
         = render partial: '/study_schedule/visit_group_page_select', locals: {arm: arm, page: page}
     .row.visit_groups

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -107,7 +107,9 @@ en:
     edit_arm: Edit Arm
     flash_messages:
       updated: "Arm Updated"
+    header: 'Clinical Services'
     name: "Arm Name"
+    name_with_arm_name_interpolated: 'Arm Name: %{arm_name}'
     not_deleted: "Protocols must have at least one arm. This arm cannot be deleted until another one is added"
     remove_arm: Remove Arm
     selected_line_items: "Selected Services"
@@ -191,20 +193,20 @@ en:
   line_item:
     object: "Line Item"
     account_number: "Account"
-    add_line_item_study: "Add Study Level Activity"
-    add_line_item_project: "Add Project Level Activity"
+    add_line_item_study: "Add Non-clinical Services"
+    add_line_item_project: "Add Non-clinical Services"
     change_service: "Change Service"
     components: "Components"
     contact: "Contact"
-    create: "Create New Study Level Activity"
-    create_project: "Create New Project Level Activity"
+    create: "Create New Non-clinical Service"
+    create_project: "Create New Non-clinical Service"
     delete_line_item: "Delete line item"
-    edit: "Edit Study Level Activity"
+    edit: "Edit Non-clinical Service"
     flash_messages:
-      created: "Study Level Activity Created"
-      deleted: "Study Level Activity Deleted"
-      not_deleted: "This Study Level Activity has Fulfillments. It cannot be deleted"
-      updated: "Study Level Activity Updated"
+      created: "Non-clinical Service Created"
+      deleted: "Non-clinical Service Deleted"
+      not_deleted: "This Non-clinical Service has Fulfillments. It cannot be deleted"
+      updated: "Non-clinical Service Updated"
     last_fulfillment: "Last Fulfillment"
     log_notes:
       quantity_requested: "Quantity Requested changed to "
@@ -337,15 +339,15 @@ en:
       remove_arm: "Remove Arm"
       remove_service: "Remove Service"
       remove_visit_group: "Remove Visit Group"
-      study_level_activities: "Study Level Activities"
+      study_level_activities: "Non-clinical Services"
     tabs:
       participant_list: "Participant List"
       participant_tracker: "Participant Tracker"
       reports: "Reports"
-      study_level_activities: "Study Level Activities"
-      project_level_activities: "Project Level Activities"
-      study_schedule: "Study Schedule"
-      project_schedule: "Project Schedule"
+      study_level_activities: "Non-clinical Services"
+      project_level_activities: "Non-clinical Services"
+      study_schedule: "Clinical Services"
+      project_schedule: "Clinical Services"
     udak_project_number: "UDAK Project #"
     updates: "Updates"
     back_to_top: 'Back to Top'

--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -1,0 +1,3 @@
+module Constants
+  AUDITING_REPORT_SERVICE_TYPES = ['Non-clinical Services', 'Clinical Services']
+end

--- a/spec/features/study_level_activities/identity_manages_documents_spec.rb
+++ b/spec/features/study_level_activities/identity_manages_documents_spec.rb
@@ -48,7 +48,7 @@ feature 'Identity manages Doucuments', js: true do
     sparc_protocol.update_attributes(type: 'Study')
     visit protocol_path(protocol.id)
     wait_for_ajax
-    click_link "Study Level Activities"
+    click_link "Non-clinical Services"
     wait_for_ajax
   end
 

--- a/spec/features/study_level_activities/identity_manages_fulfillments_spec.rb
+++ b/spec/features/study_level_activities/identity_manages_fulfillments_spec.rb
@@ -58,7 +58,7 @@ feature 'Fulfillments', js: true do
     given_i_have_fulfillments
     visit protocol_path(@protocol.id)
     wait_for_ajax
-    click_link "Study Level Activities"
+    click_link "Non-clinical Services"
     wait_for_ajax
     first('.otf-fulfillment-list').click
     wait_for_ajax

--- a/spec/features/study_level_activities/identity_manages_line_items_spec.rb
+++ b/spec/features/study_level_activities/identity_manages_line_items_spec.rb
@@ -95,7 +95,7 @@ feature 'Line Items', js: true do
     visit protocol_path(@protocol.id)
     wait_for_ajax
 
-    click_link 'Study Level Activities'
+    click_link 'Non-clinical Services'
     wait_for_ajax
   end
 
@@ -113,7 +113,7 @@ feature 'Line Items', js: true do
     visit protocol_path(@protocol.id)
     wait_for_ajax
 
-    click_link 'Study Level Activities'
+    click_link 'Non-clinical Services'
     wait_for_ajax
   end
 
@@ -180,6 +180,6 @@ feature 'Line Items', js: true do
     wait_for_ajax
     first('.notes.list[data-notable-type="LineItem"]').click
     wait_for_ajax
-    expect(page).to have_content "Study Level Activity Updated"
+    expect(page).to have_content "Non-clinical Service Updated"
   end
 end

--- a/spec/features/study_level_activities/identity_manages_notes_spec.rb
+++ b/spec/features/study_level_activities/identity_manages_notes_spec.rb
@@ -52,7 +52,7 @@ feature 'Notes', js: true do
     sparc_protocol.update_attributes(type: 'Study')
     visit protocol_path(protocol.id)
     wait_for_ajax
-    click_link "Study Level Activities"
+    click_link "Non-clinical Services"
     wait_for_ajax
   end
 


### PR DESCRIPTION
Styling

On Fulfillment Study/Project Schedule tab, I changed the calendar
service type label and the arm name styling to make it consistent with
SPARCRequest: https://www.pivotaltracker.com/story/show/144556725

[#144557683]

Story link - https://www.pivotaltracker.com/story/show/144557683